### PR TITLE
set canonical URL with www

### DIFF
--- a/content/meta/config.js
+++ b/content/meta/config.js
@@ -3,9 +3,9 @@ module.exports = {
   shortSiteTitle: "SprintSeoul", // <title> ending for posts and pages
   siteDescription:
     "오픈소스 프로젝트의 작성자 또는 기여자와 함께 짧은 시간 동안 함께 문제를 찾고 해결하며, 해당 오픈소스 프로젝트에 대해 보다 깊게 알아가는 행사입니다.",
-  siteUrl: "https://sprintseoul.org",
+  siteUrl: "https://www.sprintseoul.org",
   pathPrefix: "",
-  siteImage: "https://sprintseoul.org/sprintseoul.jpg",
+  siteImage: "https://www.sprintseoul.org/sprintseoul.jpg",
   siteLanguage: "ko",
 
   /* author */

--- a/src/components/Seo/Seo.js
+++ b/src/components/Seo/Seo.js
@@ -25,6 +25,7 @@ const Seo = props => {
       {/* General tags */}
       <title>{title}</title>
       <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
       {/* OpenGraph tags */}
       <meta property="og:url" content={url} />
       <meta property="og:title" content={title} />


### PR DESCRIPTION
It seems we use `www.sprintseoul.org` as a primary URL, but we set `og:url` with `sprintseoul.org`.

And I added `canonical` meta tag.